### PR TITLE
refactor: remove unused `discardData` in `VxConstraintManager#removeConstraint`, rename `hasActiveConstraint` to `isConstraintActive` for clarity

### DIFF
--- a/common/src/main/java/net/xmx/velthoric/core/body/server/VxServerBodyManager.java
+++ b/common/src/main/java/net/xmx/velthoric/core/body/server/VxServerBodyManager.java
@@ -370,7 +370,7 @@ public class VxServerBodyManager extends VxAbstractBodyManager {
             // If the body is not in memory, we cannot easily modify the chunk blob without
             // incurring a heavy I/O cost (loading, deserializing, filtering, saving).
             // Therefore, we only ensure that runtime constraints linking to this ID are severed.
-            world.getConstraintManager().removeConstraintsForBody(id, reason == VxRemovalReason.DISCARD);
+            world.getConstraintManager().removeConstraintsForBody(id);
             return;
         }
 
@@ -413,8 +413,7 @@ public class VxServerBodyManager extends VxAbstractBodyManager {
         body.onBodyRemoved(world, reason);
 
         // 5. Cleanup Constraints
-        // If we are discarding the body, we also want to permanently delete constraints attached to it.
-        world.getConstraintManager().removeConstraintsForBody(body.getPhysicsId(), reason == VxRemovalReason.DISCARD);
+        world.getConstraintManager().removeConstraintsForBody(body.getPhysicsId());
 
         // 6. Destroy Native Jolt Body
         // This stops the actual physics simulation for this object.

--- a/common/src/main/java/net/xmx/velthoric/core/constraint/manager/VxConstraintManager.java
+++ b/common/src/main/java/net/xmx/velthoric/core/constraint/manager/VxConstraintManager.java
@@ -91,10 +91,8 @@ public class VxConstraintManager {
         }
 
         // Remove constraints from the simulation.
-        // The 'false' parameter ensures we do not delete the persistent data from the storage index,
-        // as we are merely unloading them from RAM, not destroying them.
         for (VxConstraint constraint : constraintsToUnload) {
-            removeConstraint(constraint.getConstraintId(), false);
+            removeConstraint(constraint.getConstraintId());
         }
     }
 
@@ -251,10 +249,8 @@ public class VxConstraintManager {
      * relevant chunk is next serialized.
      *
      * @param constraintId The unique identifier of the constraint to remove.
-     * @param discardData  If true, indicates that the data should be permanently lost (e.g., broken by player).
-     *                     If false, it may imply a temporary unload or save.
      */
-    public void removeConstraint(UUID constraintId, boolean discardData) {
+    public void removeConstraint(UUID constraintId) {
         VxConstraint constraint = activeConstraints.remove(constraintId);
 
         if (constraint != null) {
@@ -275,14 +271,20 @@ public class VxConstraintManager {
         }
     }
 
-    public void removeConstraintsForBody(UUID bodyId, boolean discardData) {
+    public void removeConstraintsForBody(UUID bodyId) {
         activeConstraints.values().stream()
                 .filter(c -> c.getBody1Id().equals(bodyId) || c.getBody2Id().equals(bodyId))
-                .forEach(c -> removeConstraint(c.getConstraintId(), discardData));
+                .forEach(c -> removeConstraint(c.getConstraintId()));
         dataSystem.removeForBody(bodyId);
     }
 
-    public boolean hasActiveConstraint(UUID id) {
+    /**
+     * Checks if a constraint with the given ID is currently active in the physics simulation.
+     *
+     * @param id The UUID of the constraint to check.
+     * @return {@code true} if the constraint is active, {@code false} otherwise.
+     */
+    public boolean isConstraintActive(UUID id) {
         return activeConstraints.containsKey(id);
     }
 


### PR DESCRIPTION
To be honest, I didn't really understand whether ignoring `discardData` was added by accident or not in https://github.com/xI-Mx-Ix/Velthoric/commit/4813a5608f65b811c444e3b9922920733508106d, but I assume it's not.
I also renamed the `hasActiveConstraint` method because its name was only causing confusion about its meaning.