### PR TITLE
Make vx-native and vx-events have publishing configurations.

### DIFF
--- a/vx-events/build.gradle
+++ b/vx-events/build.gradle
@@ -11,3 +11,13 @@ dependencies {
     modImplementation "dev.architectury:architectury:$rootProject.architectury_api_version"
     include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:$mixinextras_version")))
 }
+
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = base.archivesName.get()
+            from components.java
+        }
+    }
+}

--- a/vx-native/build.gradle
+++ b/vx-native/build.gradle
@@ -125,3 +125,12 @@ processResources {
 jar {
     archiveBaseName.set("vxnative")
 }
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = base.archivesName.get()
+            from components.java
+        }
+    }
+}


### PR DESCRIPTION
This way, Velthoric can actually be pulled as a dependency from Jitpack and other actual maven repositories. Right now it is not being published anywhere public, and Jitpack is a good solution.