### PR TITLE
Add method to retrieve constraint by UUID in VxConstraintManager

### DIFF
--- a/common/src/main/java/net/xmx/velthoric/core/constraint/manager/VxConstraintManager.java
+++ b/common/src/main/java/net/xmx/velthoric/core/constraint/manager/VxConstraintManager.java
@@ -308,6 +308,16 @@ public class VxConstraintManager implements VxChunkPersistenceHandler {
         return activeConstraints.containsKey(id);
     }
 
+    /**
+     * Retrieves active constraint by given ID.
+     * @param id The UUID of the constraint to retrieve.
+     * @return the constraint, or {@code null} if constraint is not found
+     */
+    @Nullable
+    public VxConstraint getActiveConstraint(UUID id) {
+        return activeConstraints.get(id);
+    }
+
     public VxConstraintStorage getConstraintStorage() {
         return constraintStorage;
     }


### PR DESCRIPTION
Some constraint configuration can (only) be done in runtime, so it would be good to be able to get it using public API